### PR TITLE
[scenario checker tool] Fixed bug of incorrect assignation of algorithm_cutoff_memory

### DIFF
--- a/data_check_tool_python/src/coseal_reader.py
+++ b/data_check_tool_python/src/coseal_reader.py
@@ -158,7 +158,7 @@ class CosealReader(object):
             Printer.print_e("'performance_type' has to be list")
             
         self.metainfo.algorithm_cutoff_time = description.get('algorithm_cutoff_time')
-        self.metainfo.features_cutoff_memory = description.get('algorithm_cutoff_memory')
+        self.metainfo.algorithm_cutoff_memory = description.get('algorithm_cutoff_memory')
         self.metainfo.features_cutoff_time = description.get('features_cutoff_time')
         self.metainfo.features_cutoff_memory = description.get('features_cutoff_memory')
         self.metainfo.features_deterministic = description.get('features_deterministic')


### PR DESCRIPTION
Hi,

The `algorithm_cutoff_memory` was always said to be `never found` by the scenario checker, it was due to an incorrect assignation of the data to `features_cutoff_memory` instead of `algorithm_cutoff_memory`.